### PR TITLE
Switch to clap, and fix some bugs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "passgen"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 
 [dependencies]
+clap = { version = "4.5.16", features = ["derive"] }
 copypasta = "0.10.1"
 rand = "0.8.5"
-structopt = "0.3.26"

--- a/README.md
+++ b/README.md
@@ -4,31 +4,34 @@ A simple password generator in Rust
 ## Installation
 
 ```bash
-  git clone https://github.com/Keegan-JW/passgen
-  Move into $PATH
+git clone https://github.com/Keegan-JW/passgen
+cd passgen
+cargo build --release
+# Move the binary into $PATH
 ```
     
 ## Usage
 
 ```text
- USAGE:
-    passgen [FLAGS] [OPTIONS] 
+Generate random passwords
 
-FLAGS:
-    -v, --copy-password
-    -h, --help                
-    -d, --include-digits
-    -c, --include-lowercase
-    -s, --include-special
-    -u, --include-uppercase
-    -V, --version              
+Usage: passgen [OPTIONS]
 
-OPTIONS:
-    -l, --length <length>     [default: 20]
+Options:
+  -l, --length <LENGTH>    The length of the password [default: 20]
+  -u, --include-uppercase
+  -c, --include-lowercase
+  -d, --include-digits
+  -s, --include-special
+  -v, --copy-password
+  -h, --help               Print help
+  -V, --version            Print version
 ```
 
 ## Example
 
 ```bash
 passgen -l 25 -u -c -d -s
+# Or
+passgen -ucdsl 25
 ```


### PR DESCRIPTION
Switch the argument parser to clap, fix some small crashes and clean up documentation a bit